### PR TITLE
Feature/try catch

### DIFF
--- a/cloud-formation/deploy-and-curl.sh
+++ b/cloud-formation/deploy-and-curl.sh
@@ -29,5 +29,7 @@ aws cloudformation package --template-file ${TEMPLATE} --s3-bucket ${BUCKET} --o
 aws cloudformation deploy --template-file ${WORKING_TEMPLATE} --stack-name ${STACK} --capabilities CAPABILITY_IAM
 # Invoke lambda via api gateway
 curl -v -X ${METHOD} -d ${PAYLOAD} ${URL}
+# Outputs new line in terminal so prompt not on same line as previous result
+echo -ne '\n'
 
 #example of how to call> bash -x deploy-and-curl.sh cbf template.cfn.yaml '{"id":"liam"}'

--- a/cloud-formation/deploy-and-curl.sh
+++ b/cloud-formation/deploy-and-curl.sh
@@ -28,7 +28,7 @@ aws cloudformation package --template-file ${TEMPLATE} --s3-bucket ${BUCKET} --o
 # Redeploy stack
 aws cloudformation deploy --template-file ${WORKING_TEMPLATE} --stack-name ${STACK} --capabilities CAPABILITY_IAM
 # Invoke lambda via api gateway
-curl -v -X ${METHOD} -d ${PAYLOAD} ${URL}
+curl -v -X ${METHOD} -d ${PAYLOAD} -i ${URL}
 # Outputs new line in terminal so prompt not on same line as previous result
 echo -ne '\n'
 

--- a/lambda/step-lambda.js
+++ b/lambda/step-lambda.js
@@ -36,10 +36,13 @@ exports.handler = async function(event, context) {
     ReturnValues:"UPDATED_NEW"
   }
   console.log("Calling DDB", JSON.stringify(request))
-  const result = await documentClient.update(request).promise()
-  
-  //console.log("Context", JSON.stringify(context));
-  console.log(JSON.stringify(result));
 
-  return {"statusCode": 200, "body": JSON.stringify(result)}
+  try {
+    const result = await documentClient.update(request).promise()
+    return {"statusCode": 200, "body": JSON.stringify(result)}
+  }
+  catch(error){
+    return {"statusCode": error.statusCode, "body": error.message}
+  }
+
 }


### PR DESCRIPTION
Hi Simon, 

I added a try/catch to the lambda so that we could catch any errors.
I'm pretty sure it's working via what's coming back in the curl log - I was just wondering how I could get curl to print the response we are returning in the lambda? ie {statusCode = x, body = Y}

The internet mentioned using a **-i flag** but that doesn't seem to do anything


my commands to trigger:
success:  `bash -x deploy-and-curl.sh cbf template.cfn.yaml '{"id":"liam"}'`
error: `bash -x deploy-and-curl.sh cbf template.cfn.yaml '{"step":"liam"}'`