### PR TITLE
Feature/handle different methods

### DIFF
--- a/lambda/step-lambda.js
+++ b/lambda/step-lambda.js
@@ -17,7 +17,7 @@ const documentClient = new AWS.DynamoDB.DocumentClient({'region': region})
 // result is the returned proomised object (awaits until async function completed) - i promise rejected an exception is thrown
 // NB 'context' parameter has info in it tthat we could find useful and extract, although in this example we don't need it
 
-exports.handler = function(event, context) {
+exports.handler = async function(event, context) {
   //console.log(process.env.AWS_ACCESS_KEY_ID, process.env.AWS_SECRET_ACCESS_KEY, process.env.AWS_SESSION_TOKEN)
   console.log("Received event", JSON.stringify(event))
 
@@ -26,8 +26,7 @@ exports.handler = function(event, context) {
 
   switch(method) {
     case "POST":
-      handlePostRequest(event)
-      break; // not needed once have try/catch merged
+      return await handlePostRequest(event)
     case "GET":
       return {"statusCode": 500, "body": "GET logic to be implemented"}
     default:


### PR DESCRIPTION
Hi Simon, 

I added in a basic switch statement so I can start handling different requests. I haven't implemented the GET logic yet, I just wanted to make sure the POST request was still working.

Via the CloudWatch logs it looks like it's working fine, seenCount is incrementing as expected, but in the terminal I am getting a `{"message": "Internal server error"}` - any thoughts on where this is coming from or how to debug this? It's weird that the AWS logs are happy but the terminal is not.