### PR TITLE
Use of cat instead of read

### DIFF
--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -29,7 +29,7 @@ const testPostBody = {
 
 // This is ignored if we use a GET request
 const testEvent = { 
-    httpMethod: "GET",
+    httpMethod: "${METHOD}",
     body: JSON.stringify(testPostBody)
 }
 console.log(JSON.stringify(testEvent))

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -22,22 +22,22 @@ export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile
 # We are piping to stdin of read command, which lets us set a variable
 # look up read docs - read for linux, cat for mac
 #read -r -d '' SCRIPT <<'EOF'
-# cat <<'EOF'
-# const testPostBody = {
-#     id: "Sally"
-# }
+SCRIPT=$(cat <<'EOF'
+const testPostBody = {
+    id: "Sally"
+}
 
-# // This is ignored if we use a GET request
-# const testEvent = { 
-#     httpMethod: POST,
-#     body: JSON.stringify(testPostBody)
-# }
-# console.log(JSON.stringify(testEvent))
-# EOF
-
+// This is ignored if we use a GET request
+const testEvent = { 
+    httpMethod: "GET",
+    body: JSON.stringify(testPostBody)
+}
+console.log(JSON.stringify(testEvent))
+EOF
+)
 # hardcoded payload
 # PAYLOAD='{"httpMethod":"POST","body":"{\"id\":\"Sally\"}"}'
-SCRIPT="const testPostBody = {id: 'Sally'}; const testEvent = { httpMethod: '${METHOD}', body: JSON.stringify(testPostBody)}; console.log(JSON.stringify(testEvent));"
+# SCRIPT="const testPostBody = {id: 'Sally'}; const testEvent = { httpMethod: '${METHOD}', body: JSON.stringify(testPostBody)}; console.log(JSON.stringify(testEvent));"
 PAYLOAD=$(node -e "${SCRIPT}") #-e allows above script to be evaluated by node, quotes preserve new lines in script
 
 # \ allows multi-line commands, requires space before but none after

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -22,7 +22,7 @@ export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile
 # We are piping to stdin of read command, which lets us set a variable
 # look up read docs - read for linux, cat for mac
 #read -r -d '' SCRIPT <<'EOF'
-SCRIPT=$(cat <<'EOF'
+SCRIPT=$(cat <<EOF
 const testPostBody = {
     id: "Sally"
 }


### PR DESCRIPTION
One way of making the Heredoc work, from what I've read online is to use `cat` and assign to the `SCRIPT` variable.

The below works, but I couldn't figure out how to substitute the hardcoded "GET"/"POST" for the `$METHOD` variable I've created. The `$METHOD` is passed in as a parameter when running the script e.g. `./run-in-docker POST`