### PR TITLE
Add multiple items to db

### DIFF
--- a/lambda-js/src/handlers.test.js
+++ b/lambda-js/src/handlers.test.js
@@ -49,7 +49,27 @@ describe('testing dynamoScan', () => {
 
   });
 
-  
+  test('dynamoScan recurses correctly and returns all data, ', async () => {
+    // Note that the tests above use minimal data, and are only testing the base scanning function of DynamoScan
+    // To test the recursion we need to either  inset more data or reduce the scan Limit so that the dynamo response is paginated and recursion triggered
+
+    // ARRANGE - insert data
+    const ids = ['Tom', 'Michael', 'Peter']
+
+    ids.forEach(async (id) => {
+      const insertDataParams = { TableName : tableName, Item: { Id: id} };
+      await documentClient.put(insertDataParams).promise()
+    });
+
+    // ACT - run DynamoScan method
+    const result = await dynamoScan(documentClient, dynamoScanRequest) //already returns a promise
+    console.log(result)
+
+    // ASSERT - verify DynamoScan has returned correct data - expect statements
+    expect(result.length).toBe(3);
+    expect(result).toEqual([{ Id: 'Tom' }, { Id: 'Michael' }, { Id: 'Peter' }])
+
+  });
 
 
 async function createTestTable(dynamoDbClient,tableName) {

--- a/lambda-js/src/handlers.test.js
+++ b/lambda-js/src/handlers.test.js
@@ -55,19 +55,25 @@ describe('testing dynamoScan', () => {
 
     // ARRANGE - insert data
     const ids = ['Tom', 'Michael', 'Peter']
+    const insertItems = []
 
-    ids.forEach(async (id) => {
-      const insertDataParams = { TableName : tableName, Item: { Id: id} };
-      await documentClient.put(insertDataParams).promise()
+    ids.forEach((id) => {
+      const item = { PutRequest: { Item: { Id: id} } };
+     insertItems.push(item);
     });
+
+    console.log(tableName)
+
+    // tableName constant not resolving?
+    const insertDataParams = { RequestItems: { "MockTable" : insertItems }};
+    await documentClient.batchWrite(insertDataParams).promise()
 
     // ACT - run DynamoScan method
     const result = await dynamoScan(documentClient, dynamoScanRequest) //already returns a promise
-    console.log(result)
 
     // ASSERT - verify DynamoScan has returned correct data - expect statements
     expect(result.length).toBe(3);
-    expect(result).toEqual([{ Id: 'Tom' }, { Id: 'Michael' }, { Id: 'Peter' }])
+    expect(result).toEqual([{ Id: 'Michael' }, { Id: 'Peter' }, { Id: 'Tom' }]) //results returned alphabetically
 
   });
 

--- a/lambda-js/src/handlers.test.js
+++ b/lambda-js/src/handlers.test.js
@@ -55,17 +55,20 @@ describe('testing dynamoScan', () => {
 
     // ARRANGE - insert data
     const ids = ['Tom', 'Michael', 'Peter']
-    const insertItems = []
 
-    ids.forEach((id) => {
-      const item = { PutRequest: { Item: { Id: id} } };
-     insertItems.push(item);
-    });
+    // ids.forEach((id) => {
+    //   const item = { PutRequest: { Item: { Id: id} } };
+    //  insertItems.push(item);
+    // });
 
-    console.log(tableName)
+    const insertItems = ids.map( id => {
+      //because I'm returning an object - curly brackets need to remain, otherwise one liners don't need {}, nor return statement
+      return { PutRequest: { Item: { Id: id} } };
+    })
+
 
     // tableName constant not resolving?
-    const insertDataParams = { RequestItems: { "MockTable" : insertItems }};
+    const insertDataParams = { RequestItems: { [tableName] : insertItems }};
     await documentClient.batchWrite(insertDataParams).promise()
 
     // ACT - run DynamoScan method


### PR DESCRIPTION
To test the actual recursion part of the DynamoScan I need to add in more data to the table.

I couldn't see an obvious way to add multiple items at once with the DocumentClient, so I tried doing a forEach loop - but I'm not convinced it's working properly, as the table returns an empty array

**Update**: I didn't get to the bottom of why the forEach loop didn't work, however I was able to replace it with `DocumentClient.batchWrite` my only issue now is that the tableName constant won't resolve, I have to hardcode the tablename