### PR TITLE
Add unit tests for handleGetRequest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output
 working/
 node_modules/
 lambda-js/lib/
+coverage/

--- a/lambda-js/package.json
+++ b/lambda-js/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "step-lambda.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --coverage",
     "transpile": "babel src --out-dir lib",
     "invokeGet": "npm run transpile && node ./lib/run-local.js GET",
     "invokePost": "npm run transpile && node ./lib/run-local.js POST"

--- a/lambda-js/src/handlers.test.js
+++ b/lambda-js/src/handlers.test.js
@@ -1,4 +1,4 @@
-import {dynamoScan} from "./handlers" // const { dynamoScan } = require("./handlers");
+import { dynamoScan, handleGetRequest } from "./handlers" // const { dynamoScan } = require("./handlers");
 import AWS from 'aws-sdk' // in package.json //const AWS = require("aws-sdk") 
 
 describe('example test', () => {
@@ -49,8 +49,46 @@ describe('testing dynamoScan', () => {
 
   });
 
-  
+});
 
+describe('testing handleGetRequest', () => {
+  // Applies only to tests in this describe block
+  const dynamoDbClient = new AWS.DynamoDB({'region': 'eu-west-1', 'endpoint': 'http://localhost:4566' }) // region needs to match what's in docker compose
+  const documentClient = new AWS.DynamoDB.DocumentClient({'service': dynamoDbClient}) //sits on top od DDB client
+  const tableName = "MockTable"
+  const dynamoScanRequest = { TableName: tableName, Limit: 2}
+
+  beforeEach(async () => {
+    await createTestTable(dynamoDbClient,tableName)
+    // remember to use await needed so we don't continue through the code before table has finished being made
+  });
+  
+  afterEach(async () => {
+    await dynamoDbClient.deleteTable({TableName : tableName}).promise()
+  });
+
+  test('handleGetRequest returns a 200 response on success', async () => {
+    
+    // ACT 
+    const result = await handleGetRequest(documentClient, tableName);
+
+    // ASSERT 
+    expect(result.statusCode).toBe(200); 
+    expect(result.body).toEqual('[]') 
+
+  });
+
+  test('handleGetRequest returns a rejected promise on failure', async () => {
+    
+    // ACT 
+    const result = await handleGetRequest(documentClient, tableName)
+ 
+    // ASSERT 
+    expect(result).rejects.toBe('error');
+
+  });
+
+});
 
 async function createTestTable(dynamoDbClient,tableName) {
   const createTableParams = {
@@ -76,5 +114,5 @@ async function createTestTable(dynamoDbClient,tableName) {
   // create table
   await dynamoDbClient.createTable(createTableParams).promise()
 }
-});
 
+// unit test for handle post - test that if fails returns a rejected promise? successful 201 with and without step

--- a/lambda-js/src/handlers.test.js
+++ b/lambda-js/src/handlers.test.js
@@ -79,12 +79,25 @@ describe('testing handleGetRequest', () => {
   });
 
   test('handleGetRequest returns a rejected promise on failure', async () => {
+
+    //ARRANGE
+    const mockDocumentClient = {
+      scan: () => {
+        return {
+          promise: jest.fn().mockRejectedValue('error')}
+      }
+    };
+
     
-    // ACT 
-    const result = await handleGetRequest(documentClient, tableName)
+    // ACT - don't await
+    const result = handleGetRequest(mockDocumentClient, tableName)
  
     // ASSERT 
     expect(result).rejects.toBe('error');
+
+    //alternative with await - pass it a function, execution deferred until inside expect (if not it's run immediately)
+    // we can't use awaits and expect to throw
+    // expect( async () => { await handleGetRequest(mockDocumentClient, tableName)}).toThrow('error')
 
   });
 


### PR DESCRIPTION
I've created the two unit tests for handleGetRequest
- the first tests a positive scenario returns a 200
- the latter is supposed to check that in the situation where handleGetRequest fails, it should return a rejected promise. Though I couldn't figure out how to trigger this? Is this even possible?